### PR TITLE
Fix KeyError: 'journeys'

### DIFF
--- a/locomotive/api/oui_v3.py
+++ b/locomotive/api/oui_v3.py
@@ -60,7 +60,7 @@ class Client(TravelClient):
         self.logger.debug(res.request.body)
         self.logger.debug(res.content)
 
-        if res.status_code == 404:
+        if res.status_code == 404 or "error" in res.json():
             # {"code":"ERR-0102","label":"empty travel result"}
             return {"journeys": []}
 


### PR DESCRIPTION
I also had to patch some dependencies versions in order to install `locomotive` without raising errors:
```
pip install markupsafe==2.0.1 'regex<2022.3.15'
```

This PR won't fix the root issue that prevents `locomotive` from working, which is that the API return this error:
```json
{"code": "UPE-0001", "label": "error.client.incompatible.api", 'error': 'INCOMPATIBLE_CLIENT'}
```